### PR TITLE
Fix glob expand when the suffix of the glob is **/*

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -328,6 +328,7 @@ module Pod
           end.uniq
         elsif extensions && File.extname(glob).empty?
           extensions.map do |ext|
+            glob.chomp!('**/*') # If we reach here and the glob ends with **/*, we need to avoid duplicating it (we do not want to end up with **/*/**/*)
             File.join(glob, '**', "*.#{ext}")
           end
         elsif expand_directories


### PR DESCRIPTION
You can see the problem this PR solves if you run `cocoapods-bazel` with the pod `InputMask`version `4.2.0`