### PR TITLE
Handle {USER_,}HEADER_SEARCH_PATHS in xcconfigs specially

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -123,6 +123,14 @@ module Pod
         super(setting, settings: settings)
       end
 
+      def pod_target_xcconfig_header_search_paths
+        resolved_build_setting_value('HEADER_SEARCH_PATHS', settings: pod_target_xcconfig.merge('PODS_TARGET_SRCROOT' => @package)) || []
+      end
+
+      def pod_target_xcconfig_user_header_search_paths
+        resolved_build_setting_value('USER_HEADER_SEARCH_PATHS', settings: pod_target_xcconfig.merge('PODS_TARGET_SRCROOT' => @package)) || []
+      end
+
       def to_rule_kwargs
         kwargs = RuleArgs.new do |args|
           args
@@ -205,6 +213,18 @@ module Pod
         kwargs[:objc_copts] = resolved_build_setting_value('OTHER_CFLAGS') || []
         kwargs[:linkopts] = resolved_build_setting_value('OTHER_LDFLAGS') || []
         # kwargs[:cc_copts] = resolved_build_setting_value('${OTHER_CFLAGS} ${OTHER_CPPFLAGS}') || []
+
+        pod_target_xcconfig_header_search_paths.each do |path|
+          iquote = "-I#{path}"
+          kwargs[:objc_copts] << iquote
+          kwargs[:swift_copts] << '-Xcc' << iquote
+        end
+
+        pod_target_xcconfig_user_header_search_paths.each do |path|
+          i = "-iquote#{path}"
+          kwargs[:objc_copts] << i
+          kwargs[:swift_copts] << '-Xcc' << i
+        end
 
         # propagated
         kwargs[:defines] = []

--- a/lib/cocoapods/bazel/xcconfig_resolver.rb
+++ b/lib/cocoapods/bazel/xcconfig_resolver.rb
@@ -27,12 +27,14 @@ module Pod
 
       UNRESOLVED_SETTINGS = [
         'CONFIGURATION', # not needed, only used to help resolve other settings that may use it in substitutions
+        'HEADER_SEARCH_PATHS', # serialized into copts, handled natively by Xcode instead of via xcspecs
         'OTHER_CFLAGS', # serialized separately as objc_copts
         'OTHER_SWIFT_FLAGS', # serialized separately as swift_copts
         'PODS_TARGET_SRCROOT', # not needed, used to help resolve file references relative to the current package
         'SDKROOT', # not needed since the SDKROOT gets propagated via the apple configuration transition
         'SRCROOT', # not needed, used to help resolve file references relative to the current workspace
-        'SWIFT_VERSION' # serialized separately as swift_version
+        'SWIFT_VERSION', # serialized separately as swift_version
+        'USER_HEADER_SEARCH_PATHS' # serialized into copts, handled natively by Xcode instead of via xcspecs
       ].freeze
       private_constant :UNRESOLVED_SETTINGS
 

--- a/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "CustomHeaderSearchPaths",
+    srcs = glob([
+        "Sources/**/*.h",
+        "Sources/**/*.m",
+        "Sources/**/*.swift",
+    ]),
+    objc_copts = ["-IFrameworks/CustomHeaderSearchPaths/Sources"],
+    platforms = {"ios": "9.0"},
+    private_headers = glob(["Sources/Internal/**/*.h"]),
+    swift_copts = [
+        "-Xcc",
+        "-IFrameworks/CustomHeaderSearchPaths/Sources",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/CustomHeaderSearchPaths.podspec
+++ b/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/CustomHeaderSearchPaths.podspec
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Pod::Spec.new do |s|
+    s.name = 'CustomHeaderSearchPaths'
+    s.version = '1.0.0.LOCAL'
+  
+    s.authors = %w[Square]
+    s.homepage = 'https://github.com/Square/cocoapods-generate'
+    s.source = { git: 'https://github.com/Square/cocoapods-generate' }
+    s.summary = 'Testing pod'
+  
+    s.swift_versions = %w[5.2]
+    s.ios.deployment_target = '9.0'
+  
+    s.source_files = 'Sources/**/*.{h,m,swift}'
+    s.private_header_files = 'Sources/Internal/**/*.h'
+    s.pod_target_xcconfig = {
+        'HEADER_SEARCH_PATHS' => ['${PODS_TARGET_SRCROOT}/Sources']
+    }
+end

--- a/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/Internal/InternalHeader.h
+++ b/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/Internal/InternalHeader.h
@@ -1,0 +1,4 @@
+#import "PublicHeader.h"
+
+@protocol InternalProtocol
+@end

--- a/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/PublicClass.m
+++ b/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/PublicClass.m
@@ -1,0 +1,8 @@
+#import <CustomHeaderSearchPaths/PublicHeader.h>
+#import "Internal/InternalHeader.h"
+
+@interface PublicClass () <InternalProtocol>
+@end
+
+@implementation PublicClass
+@end

--- a/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/PublicHeader.h
+++ b/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/PublicHeader.h
@@ -1,0 +1,4 @@
+@import Foundation;
+
+@interface PublicClass : NSObject
+@end


### PR DESCRIPTION
Because these two build settings are native settings in Xcode (not defined by xcconfigs), we have to expand them ourselves and put them into copts