### PR TITLE
Handle pods that have an SDKROOT reference in their xcconfig

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -115,7 +115,8 @@ module Pod
           .merge(
             'CONFIGURATION' => configuration.to_s.capitalize,
             'PODS_TARGET_SRCROOT' => ':',
-            'SRCROOT' => ':'
+            'SRCROOT' => ':',
+            'SDKROOT' => '__BAZEL_XCODE_SDKROOT__'
           )
       end
 

--- a/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
@@ -7,12 +7,17 @@ apple_framework(
         "Sources/**/*.m",
         "Sources/**/*.swift",
     ]),
-    objc_copts = ["-IFrameworks/CustomHeaderSearchPaths/Sources"],
+    objc_copts = [
+        "-IFrameworks/CustomHeaderSearchPaths/Sources",
+        "-I__BAZEL_XCODE_SDKROOT__/usr/include/libxml2",
+    ],
     platforms = {"ios": "9.0"},
     private_headers = glob(["Sources/Internal/**/*.h"]),
     swift_copts = [
         "-Xcc",
         "-IFrameworks/CustomHeaderSearchPaths/Sources",
+        "-Xcc",
+        "-I__BAZEL_XCODE_SDKROOT__/usr/include/libxml2",
     ],
     visibility = ["//visibility:public"],
 )

--- a/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/CustomHeaderSearchPaths.podspec
+++ b/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/CustomHeaderSearchPaths.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
     s.source_files = 'Sources/**/*.{h,m,swift}'
     s.private_header_files = 'Sources/Internal/**/*.h'
     s.pod_target_xcconfig = {
-        'HEADER_SEARCH_PATHS' => ['${PODS_TARGET_SRCROOT}/Sources']
+        'HEADER_SEARCH_PATHS' => ['${PODS_TARGET_SRCROOT}/Sources', '$(SDKROOT)/usr/include/libxml2']
     }
 end

--- a/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/PublicClass.m
+++ b/spec/integration/monorepo/before/Frameworks/CustomHeaderSearchPaths/Sources/PublicClass.m
@@ -1,5 +1,6 @@
 #import <CustomHeaderSearchPaths/PublicHeader.h>
 #import "Internal/InternalHeader.h"
+#import <libxml/parser.h>
 
 @interface PublicClass () <InternalProtocol>
 @end


### PR DESCRIPTION
For example, https://github.com/SVGKit/SVGKit/blob/2a4068f0ea546dcd82f7e4dd9aa9026c0a0a2235/SVGKit.podspec#L32