### PR TITLE
Adds lexigraphic sorting logic for Bazel deps

### DIFF
--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -4,6 +4,7 @@ require 'starlark_compiler/build_file'
 require 'cocoapods/bazel/config'
 require 'cocoapods/bazel/target'
 require 'cocoapods/bazel/xcconfig_resolver'
+require 'cocoapods/bazel/util'
 
 module Pod
   module Bazel

--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -223,9 +223,8 @@ module Pod
         kwargs[:vendored_dynamic_libraries] = glob(attr: :vendored_dynamic_libraries, return_files: true)
 
         # any compatible provider: CCProvider, SwiftInfo, etc
-        kwargs[:deps] = dependent_targets
-                        .map { |dt| dt.bazel_label(relative_to: package) }
-                        .sort_by { |l| [l.start_with?(':') ? -2 : -1, l] }
+        labels = dependent_targets.map { |dt| dt.bazel_label(relative_to: package) }
+        kwargs[:deps] = Pod::Bazel::Util.sort_labels(labels)
 
         case non_library_spec&.spec_type
         when :test

--- a/lib/cocoapods/bazel/util.rb
+++ b/lib/cocoapods/bazel/util.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Pod
+  module Bazel
+    module Util
+      module_function
+
+      def sort_labels(labels)
+        sort_keys = labels.map.with_index { |string, i| SortKey.new(string, i) }
+        sort_keys.sort_by { |k| [k.phase, k.split, k.value, k.original_index] }.map(&:value)
+      end
+
+      class SortKey
+        attr_reader :phase, :split, :value, :original_index
+
+        def initialize(string, index)
+          @value = string
+          @original_index = index
+          @phase = if string.start_with?(':')
+                     1
+                   elsif string.start_with?('//')
+                     2
+                   elsif string.start_with?('@')
+                     3
+                   else
+                     4
+                   end
+
+          @split = string.split(/[:.]/)
+        end
+      end
+    end
+  end
+end

--- a/spec/cocoapods/bazel/util_spec.rb
+++ b/spec/cocoapods/bazel/util_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe Pod::Bazel::Util do
+  it 'sorts Bazel labels as expected' do
+    mixed_bazel_labels = [
+      'Last',
+      '@Third:Test',
+      '//ProjectRoot/Project/AppProjectSDK/Wiring:AppProjectSDKWiring',
+      '//ProjectRoot/Project/AppProjectSetupHelp',
+      '//ProjectRoot/Project/SharedUtilities',
+      '//ProjectRoot/Project/SharedUtilities/Wiring:SharedUtilitiesWiring',
+      '//ProjectRoot/Project/StandardApis',
+      'Last:SuperLast',
+      '//ProjectRoot/Project/AppProjectSetupHelp/FakeTest:AppProjectSetupHelpFakeTest',
+      '//ProjectRoot/Project/AppProjectSetupHelp:AppProjectSetupHelpFake',
+      '//ProjectRoot/Project/AppProjectSDK',
+      ':First',
+      '@Third',
+      ':First/First:Second'
+    ]
+
+    expected = [
+      ':First',
+      ':First/First:Second',
+      '//ProjectRoot/Project/AppProjectSDK',
+      '//ProjectRoot/Project/AppProjectSDK/Wiring:AppProjectSDKWiring',
+      '//ProjectRoot/Project/AppProjectSetupHelp',
+      '//ProjectRoot/Project/AppProjectSetupHelp:AppProjectSetupHelpFake',
+      '//ProjectRoot/Project/AppProjectSetupHelp/FakeTest:AppProjectSetupHelpFakeTest',
+      '//ProjectRoot/Project/SharedUtilities',
+      '//ProjectRoot/Project/SharedUtilities/Wiring:SharedUtilitiesWiring',
+      '//ProjectRoot/Project/StandardApis',
+      '@Third',
+      '@Third:Test',
+      'Last',
+      'Last:SuperLast'
+    ]
+
+    sorted = Pod::Bazel::Util.sort_labels(mixed_bazel_labels)
+    expect(sorted).to eq(expected)
+  end
+end
+
+RSpec.describe Pod::Bazel::Util::SortKey do
+  describe 'SortKey .initialize' do
+    it 'returns a sort key object' do
+      key = Pod::Bazel::Util::SortKey.new('not a Bazel label', 0)
+      expect(key).to_not be_nil
+    end
+
+    it 'assigns the correct phase to Bazel labels' do
+      key = Pod::Bazel::Util::SortKey.new(':Something', 0)
+      expect(key.phase).to eq(1)
+
+      key = Pod::Bazel::Util::SortKey.new('//Something', 0)
+      expect(key.phase).to eq(2)
+
+      key = Pod::Bazel::Util::SortKey.new('@Something', 0)
+      expect(key.phase).to eq(3)
+
+      key = Pod::Bazel::Util::SortKey.new('Regular Something', 0)
+      expect(key.phase).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
## Priority
Normal

## What Changed & Why
Buildifier  sorts dep lists lexicographically using a [specific sort key](https://github.com/bazelbuild/buildtools/blob/daa2a2cfc23c13d3e893644d6015c54c77738be6/build/rewrite.go#L560-L578). This implements a `sort_labels` method that can be mixed in to the `Array` class to allow us to take an array of Bazel dependencies, and generate deplists in the same way that Buildifier expects. 