### PR TITLE
Makes //Pods/cocoapods-bazel:config globally visible so that we can u…

### DIFF
--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -52,7 +52,7 @@ module Pod
       configs_build_file = StarlarkCompiler::BuildFile.new(workspace: workspace, package: cocoapods_bazel_pkg)
 
       configs_build_file.add_load(of: 'string_flag', from: '@bazel_skylib//rules:common_settings.bzl')
-      configs_build_file.add_target StarlarkCompiler::AST::FunctionCall.new('string_flag', name: 'config', build_setting_default: 'debug')
+      configs_build_file.add_target StarlarkCompiler::AST::FunctionCall.new('string_flag', name: 'config', build_setting_default: 'debug', visibility: ['//visibility:public'])
       configs_build_file.add_target StarlarkCompiler::AST::FunctionCall.new('config_setting', name: 'debug', flag_values: { ':config' => 'debug' })
       configs_build_file.add_target StarlarkCompiler::AST::FunctionCall.new('config_setting', name: 'release', flag_values: { ':config' => 'release' })
 

--- a/spec/integration/monorepo/after/Pods/cocoapods-bazel/BUILD.bazel
+++ b/spec/integration/monorepo/after/Pods/cocoapods-bazel/BUILD.bazel
@@ -3,6 +3,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 string_flag(
     name = "config",
     build_setting_default = "debug",
+    visibility = ["//visibility:public"],
 )
 
 config_setting(


### PR DESCRIPTION
…se it in other config_settings