### PR TITLE
Raise error and offer suggestion if pod path is outside of current workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+0.1.1
+
+* Raise error and offer suggestion if pod path is outside of current workspace

--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -31,6 +31,7 @@ module Pod
               Current workspace: #{workspace}
             MSG
           end
+
           build_file = build_files[package]
 
           bazel_targets = [Target.new(installer, pod_target, nil, default_xcconfigs)] +

--- a/lib/cocoapods/bazel/version.rb
+++ b/lib/cocoapods/bazel/version.rb
@@ -2,6 +2,6 @@
 
 module Pod
   module Bazel
-    VERSION = '0.1.0'
+    VERSION = '0.1.1'
   end
 end


### PR DESCRIPTION
Because Bazel does not allow accessing files outside of current workspace, we raise error if detected relative path starts with `..`

TODO
- [x] Write rspec test (skip adding test for now)
Note:
This change is tested against a downstream project where the symlink is done in order to keep a Pod sitting outside a project. Everything works (xcode project gen, bazel build etc.)