### PR TITLE
Supports info.plist in framework

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -550,8 +550,12 @@ module Pod
       end
 
       def framework_kwargs
+        library_spec = pod_target.file_accessors.find { |fa| fa.spec.library_specification? }.spec
         {
           visibility: ['//visibility:public'],
+          bundle_id: resolved_value_by_build_setting('PRODUCT_BUNDLE_IDENTIFIER'),
+          infoplists_by_build_setting: pod_target_infoplists_by_build_setting,
+          infoplists: common_pod_target_infoplists(additional_plist: nil_if_empty(library_spec.consumer(pod_target.platform).info_plist)),
           platforms: { rules_ios_platform_name(pod_target.platform) => build_os_version || pod_target.platform.deployment_target.to_s }
         }
       end

--- a/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
@@ -9,6 +9,7 @@ apple_framework(
         "Sources/**/*.m",
         "Sources/**/*.swift",
     ]),
+    infoplists = [{"CFBundleShortVersionString": "1.0.0"}],
     platforms = {"ios": "11.0"},
     private_headers = glob(["Sources/Internal/**/*.h"]),
     swift_version = "5.2",

--- a/spec/integration/monorepo/before/Frameworks/a/A.podspec
+++ b/spec/integration/monorepo/before/Frameworks/a/A.podspec
@@ -15,6 +15,10 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/**/*.{h,m,swift}'
   s.private_header_files = 'Sources/Internal/**/*.h'
 
+  s.info_plist = {
+    'CFBundleShortVersionString' => '1.0.0'
+  }
+
   s.test_spec 'Tests' do |ts|
     ts.source_files = 'Tests/**/*.{h,m,swift}'
   end


### PR DESCRIPTION
When distributing a framework to third-party developers, we will need to include the info.plist into the framework.

rules_ios support: https://github.com/bazel-ios/rules_ios/pull/299