### PR TITLE
Adding supported architectures filter for armv7s and arm64e

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -636,6 +636,13 @@ module Pod
         end
       end
 
+      def supported_archs_filter(arch)
+        filtered = arch.filter {|type|
+          type != "arm64e" && type != "armv7s"
+        }
+        filtered
+      end
+
       def vendored_xcframeworks
         pod_target.xcframeworks.values.flatten(1).uniq.map do |xcframework|
           {
@@ -645,7 +652,7 @@ module Pod
                 'identifier' => slice.identifier,
                 'platform' => rules_ios_platform_name(slice.platform),
                 'platform_variant' => slice.platform_variant.to_s,
-                'supported_archs' => slice.supported_archs,
+                'supported_archs' => supported_archs_filter(slice.supported_archs),
                 'path' => slice.path.relative_path_from(@package_dir).to_s,
                 'build_type' => { 'linkage' => slice.build_type.linkage.to_s, 'packaging' => slice.build_type.packaging.to_s }
               }


### PR DESCRIPTION
I was receiving an error for vendored xcframeworks that list arm64e and armv7s as supported architectures, but filtering them out fixed the issue.

The error was showing `no such target '@build_bazel_rules_apple//apple:ios_armv7s': target 'ios_armv7s' not declared in package 'apple' (did you mean 'ios_armv7'?)`