### PR TITLE
Removing expand_directories for resource_bundle

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -342,7 +342,7 @@ module Pod
           fa.spec_consumer.resource_bundles.each do |name, file_patterns|
             bundle = bundles[name] ||= {}
             patterns_by_exclude = bundle[fa.spec_consumer.exclude_files] ||= []
-            patterns_by_exclude.concat(file_patterns.flat_map { |g| expand_glob(g, expand_directories: true) })
+            patterns_by_exclude.concat(file_patterns.flat_map { |g| expand_glob(g, expand_directories: false) })
           end
         end.tap do |bundles|
           kwargs[:resource_bundles] = bundles.map do |bundle_name, patterns_by_excludes|


### PR DESCRIPTION
When a file pattern of `*.lproj` is given to the glob function in `s.resource_bundles`, cocoapods-bazel currently expands it to two new file patterns: `*.lproj` and `*.lproj/**/*`.  This causes a duplicate output path conflict.

The fix is to not expand directories for resource bundles as that codepath is what causes the duplilcate.

Codepath that duplicates the pattern: [Target.rb Line 545](https://github.com/bazel-ios/cocoapods-bazel/blob/f9a6a9364409ffc8f10a2e91171929c8cc372692/lib/cocoapods/bazel/target.rb#L545)

I've also created a small demo project with one Pod that demonstrates the issue
https://github.com/ethan-gates/ExpandGlobDemo