### PR TITLE
Add experimental option to generate dependencies labels against an external repository

### DIFF
--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -26,7 +26,7 @@ module Pod
         build_files = Hash.new { |h, k| h[k] = StarlarkCompiler::BuildFile.new(workspace: workspace, package: k) }
         installer.pod_targets.each do |pod_target|
           package = sandbox.pod_dir(pod_target.pod_name).relative_path_from(workspace).to_s
-          if package.start_with?('..')
+          if package.start_with?('..') and not config.external_repository
             raise Informative, <<~MSG
               Bazel does not support Pod located outside of current workspace: \"#{package}\".
               To fix this, you can move the Pod into workspace,
@@ -44,7 +44,8 @@ module Pod
               pod_target,
               fa.spec,
               default_xcconfigs,
-              config.experimental_deps_debug_and_release
+              config.experimental_deps_debug_and_release,
+              config.external_repository
             )
           end
 
@@ -53,7 +54,8 @@ module Pod
             pod_target,
             nil,
             default_xcconfigs,
-            config.experimental_deps_debug_and_release
+            config.experimental_deps_debug_and_release,
+            config.external_repository
           )
 
           bazel_targets = [default_target] + targets_without_library_specification

--- a/lib/cocoapods/bazel/config.rb
+++ b/lib/cocoapods/bazel/config.rb
@@ -8,7 +8,7 @@ module Pod
         # When enabled cocoapods-bazel will add one additional config_setting for the 'deps' attribute only
         # containing both 'debug' and 'release' dependencies.
         #
-        # In other works when this flag is active cocoapods-bazel will continue to create these:
+        # In other words when this flag is active cocoapods-bazel will continue to create these:
         #
         # - //Pods/cocoapods-bazel:debug
         # - //Pods/cocoapods-bazel:release
@@ -40,7 +40,16 @@ module Pod
         # This might be ok for some teams but it prevents others that are interested in using cocoapods-bazel to migrate to Bazel and eventually stop
         # depending on cocoapods. If the generated BUILD files don't contain "all" states and a 'pod install' is always required it's not trivial how to eventually treat the
         # BUILD files as source of truth.
-        :experimental_deps_debug_and_release
+        :experimental_deps_debug_and_release,
+        # When enabled, cocoapods-bazel will generate pod dependencies with labels pointing to an external "Pods" repository
+        # For Example:
+        #
+        # //Pods/SomePod
+        # 
+        # Becomes
+        #
+        # @Pods//SomePod
+        :external_repository
       ].freeze
       private_constant :PLUGIN_KEY
       DEFAULTS = {
@@ -53,9 +62,9 @@ module Pod
         buildifier: true,
         default_xcconfigs: {}.freeze,
         features: {
-          experimental_deps_debug_and_release: false
+          experimental_deps_debug_and_release: false,
+          external_repository: false
         },
-        external_repository: false
       }.with_indifferent_access.freeze
 
       private_constant :DEFAULTS
@@ -112,7 +121,7 @@ module Pod
         to_h[:features][:experimental_deps_debug_and_release]
       end
       def external_repository
-        to_h[:external_repository]
+        to_h[:features][:external_repository]
       end
     end
   end

--- a/lib/cocoapods/bazel/config.rb
+++ b/lib/cocoapods/bazel/config.rb
@@ -54,7 +54,8 @@ module Pod
         default_xcconfigs: {}.freeze,
         features: {
           experimental_deps_debug_and_release: false
-        }
+        },
+        external_repository: false
       }.with_indifferent_access.freeze
 
       private_constant :DEFAULTS
@@ -109,6 +110,9 @@ module Pod
 
       def experimental_deps_debug_and_release
         to_h[:features][:experimental_deps_debug_and_release]
+      end
+      def external_repository
+        to_h[:external_repository]
       end
     end
   end


### PR DESCRIPTION
Rather than have all dependency labels be absolute (`//Pods/SomePod`) this experimental option generates labels to point to an external repository, allowing a more flexible folder structure, since your `Pods` folder doesn't need to be in the root

`//Pods/SomePod` -> `@Pods//SomePod`

This obviously needs to work in conjunction with a repository rule, which I have a basic implementation of that works, if theres a place I can PR that to, I'd be happy to do that

just trying to utilize this plugin for my situation without needing to maintain a fork

The project i'm working on is a multi platform mono-repo, so we want to be able to isolate the ios files into an `ios` folder, rather than polluting the root of the repo with pod related files