### PR TITLE
Do not remove a xcconfig entry if value is empty

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   integration_tests:
     name: Build and Test
-    runs-on: macos-10.15 # Check out which xcode to use if updating macos:https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
+    runs-on: macos-latest # Check out which xcode to use if updating macos:https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
     steps:
       - uses: actions/checkout@v1
-      - name: Select Xcode 12.5
-        run: sudo xcode-select -s /Applications/Xcode_12.5.app/Contents/Developer
+      - name: Print Xcode version
+        run: sudo xcode-select -p
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: "2.x" # Version range or exact version of a Ruby version to use, using semvers version range syntax.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Select Xcode 12.5
-        run: sudo xcode-select -s /Applications/Xcode_12.5.app
+        run: sudo xcode-select -s /Applications/Xcode_12.5.app/Contents/Developer
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: "2.x" # Version range or exact version of a Ruby version to use, using semvers version range syntax.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   integration_tests:
     name: Build and Test
-    runs-on: macos-latest
+    runs-on: macos-10.15 # Check out which xcode to use if updating macos:https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-software
     steps:
       - uses: actions/checkout@v1
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Select Xcode 12.5
+        run: sudo xcode-select -s /Applications/Xcode_12.5.app
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: "2.x" # Version range or exact version of a Ruby version to use, using semvers version range syntax.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.DS_Store
 
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+0.1.3
+
+* Key-value pairs with empty value is now preserved under xcconfigs instead being deleted
+
 0.1.2
 
 * Generate empty BUILD.bazel file at sandbox root (Pods/) during build file generation stage

--- a/lib/cocoapods/bazel/version.rb
+++ b/lib/cocoapods/bazel/version.rb
@@ -2,6 +2,6 @@
 
 module Pod
   module Bazel
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/lib/cocoapods/bazel/xcconfig_resolver.rb
+++ b/lib/cocoapods/bazel/xcconfig_resolver.rb
@@ -46,7 +46,7 @@ module Pod
 
         xcconfig.each_key { |k| xcconfig[k] = resolved_build_setting_value(k, settings: xcconfig) }
         xcconfig.delete_if do |k, v|
-          UNRESOLVED_SETTINGS.include?(k) || v.empty?
+          UNRESOLVED_SETTINGS.include?(k)
         end
 
         unless matching_defaults.empty?

--- a/lib/cocoapods/bazel/xcconfig_resolver.rb
+++ b/lib/cocoapods/bazel/xcconfig_resolver.rb
@@ -45,7 +45,7 @@ module Pod
         end
 
         xcconfig.each_key { |k| xcconfig[k] = resolved_build_setting_value(k, settings: xcconfig) }
-        xcconfig.delete_if do |k, v|
+        xcconfig.delete_if do |k, _v|
           UNRESOLVED_SETTINGS.include?(k)
         end
 

--- a/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
+++ b/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
@@ -12,18 +12,22 @@ RSpec.describe Pod::Bazel::XCConfigResolver do
       'ENABLE_TESTABILITY_Debug' => 'YES',
       'ENABLE_TESTABILITY_Release' => 'NO',
       'ENABLE_TESTABILITY' => '$(ENABLE_TESTABILITY_$(CONFIGURATION))',
+      'EMPTY_CONFIG' => '',
 
       'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) foo bar=1 "baz=${ENABLE_TESTABILITY}"',
 
-      'CONFIGURATION' => 'Debug'
+      'CONFIGURATION' => 'Debug',
     )
     expect(default_config_name).to be_nil
     expect(resolved).to eq(
       'ENABLE_TESTABILITY' => 'YES',
       'ENABLE_TESTABILITY_Debug' => 'YES',
       'ENABLE_TESTABILITY_Release' => 'NO',
+      'EMPTY_CONFIG' => '',
 
-      'GCC_PREPROCESSOR_DEFINITIONS' => ['foo', 'bar=1', 'baz=YES']
+      'GCC_PREPROCESSOR_DEFINITIONS' => ['foo', 'bar=1', 'baz=YES'],
+
+      'FOO_BAR' => ''
     )
   end
 end

--- a/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
+++ b/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Pod::Bazel::XCConfigResolver do
 
       'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) foo bar=1 "baz=${ENABLE_TESTABILITY}"',
 
-      'CONFIGURATION' => 'Debug',
+      'CONFIGURATION' => 'Debug'
     )
     expect(default_config_name).to be_nil
     expect(resolved).to eq(

--- a/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
+++ b/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe Pod::Bazel::XCConfigResolver do
       'ENABLE_TESTABILITY_Release' => 'NO',
       'EMPTY_CONFIG' => '',
 
-      'GCC_PREPROCESSOR_DEFINITIONS' => ['foo', 'bar=1', 'baz=YES'],
-
-      'FOO_BAR' => ''
+      'GCC_PREPROCESSOR_DEFINITIONS' => ['foo', 'bar=1', 'baz=YES']
     )
   end
 end

--- a/spec/integration/experimental_features/after/Frameworks/b/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/b/BUILD.bazel
@@ -169,6 +169,7 @@ ios_application(
         },
         "//Pods/cocoapods-bazel:release": {
             "INFOPLIST_FILE": "Resources/release.plist",
+            "CODE_SIGN_ENTITLEMENTS": "",
             "PRODUCT_BUNDLE_IDENTIFIER": "org.cocoapods.B-DebuggableOnlyApp",
         },
     },

--- a/spec/integration/experimental_features/spec.yml
+++ b/spec/integration/experimental_features/spec.yml
@@ -1,1 +1,1 @@
-description: generates build files in a CocoaPods monorepo
+description: generates build files in a CocoaPods monorepo with experimental features on

--- a/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
@@ -169,6 +169,7 @@ ios_application(
         },
         "//Pods/cocoapods-bazel:release": {
             "INFOPLIST_FILE": "Resources/release.plist",
+            "CODE_SIGN_ENTITLEMENTS": "",
             "PRODUCT_BUNDLE_IDENTIFIER": "org.cocoapods.B-DebuggableOnlyApp",
         },
     },

--- a/spec/integration/monorepo/before/Frameworks/a/A.podspec
+++ b/spec/integration/monorepo/before/Frameworks/a/A.podspec
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Pod::Spec.new do |s|
-  other_cflags = '-Wno-conversion -Wno-error=at-protocol'
   s.name = 'A'
   s.version = '1.0.0.LOCAL'
 
@@ -30,7 +29,7 @@ Pod::Spec.new do |s|
     as.pod_target_xcconfig = {
       'ARCHS' => 'arm64 x86',
       'HEADER_SEARCH_PATHS'=> "${PODS_ROOT}/Headers/Private",
-      'OTHER_CFLAGS' => other_cflags,
+      'OTHER_CFLAGS' => '-Wno-conversion -Wno-error=at-protocol',
       'OTHER_LDFLAGS' => '-all_load',
       'OTHER_SWIFT_FLAGS' => '-DDEBUG',
       'VERSIONING_SYSTEM' => 'apple-generic',

--- a/spec/integration/monorepo/before/Frameworks/a/A.podspec
+++ b/spec/integration/monorepo/before/Frameworks/a/A.podspec
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Pod::Spec.new do |s|
+  other_cflags = '-Wno-conversion -Wno-error=at-protocol'
   s.name = 'A'
   s.version = '1.0.0.LOCAL'
 
@@ -29,7 +30,7 @@ Pod::Spec.new do |s|
     as.pod_target_xcconfig = {
       'ARCHS' => 'arm64 x86',
       'HEADER_SEARCH_PATHS'=> "${PODS_ROOT}/Headers/Private",
-      'OTHER_CFLAGS' => '-Wno-conversion -Wno-error=at-protocol',
+      'OTHER_CFLAGS' => other_cflags,
       'OTHER_LDFLAGS' => '-all_load',
       'OTHER_SWIFT_FLAGS' => '-DDEBUG',
       'VERSIONING_SYSTEM' => 'apple-generic',


### PR DESCRIPTION
### Why this change
Because each key will be used in build setting side as substitution, if we just remove the key if value is empty, we will end up not having the substitution to work with in the first place. Here we simply preserve the key value pairs with empty values. 

### Tests done
1. rspec to red-green test
2. integartion tests that red-green
3. tested with downstream project that is affected by this and indeed it works.

Also did the following changes:
1. Remove xcode-select step as it was not working and I don't think any integration tests here depends on a specific xcode version?
2. Update gitignore, and test.yml for experiement_feature integartion spec

