### PR TITLE
Fix broken CI pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Select Xcode 12.2
-        run: sudo xcode-select -s /Applications/Xcode_12.2.app
+      - name: Print Xcode version
+        run: sudo xcode-select -p
       - uses: actions/setup-ruby@v1
         with:
           ruby-version: "2.x" # Version range or exact version of a Ruby version to use, using semvers version range syntax.

--- a/spec/integration/experimental_features/spec.yml
+++ b/spec/integration/experimental_features/spec.yml
@@ -1,1 +1,1 @@
-description: generates build files in a CocoaPods monorepo
+description: generates build files in a CocoaPods monorepo with experiment feature on


### PR DESCRIPTION
it;'s fine to use latest xcode

broken CI: https://github.com/bazel-ios/cocoapods-bazel/runs/4740577782?check_suite_focus=true