### PR TITLE
Ability to append comment to top of each build file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 
 # rspec failure tracking
 .rspec_status
+
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.1.3
+
+* Add ability to insert a docstring at top of generated build files
 
 0.1.2
 

--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -71,7 +71,7 @@ module Pod
           build_files.each_key.each do |key|
             path = File.join(workspace, key, 'BUILD.bazel')
             content = File.read(path)
-            File.write(path, "# #{config.build_file_doc}\n\n" + content)
+            File.write(path, "'''\n#{config.build_file_doc}\n'''\n\n" + content)
           end
         end
 

--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -67,6 +67,13 @@ module Pod
 
         build_files.each_value(&:save!)
         format_files(build_files: build_files, buildifier: config.buildifier, workspace: workspace)
+        unless config.build_file_doc.empty?
+          build_files.each_key.each do |key|
+            path = File.join(workspace, key, 'BUILD.bazel')
+            content = File.read(path)
+            File.write(path, "# #{config.build_file_doc}\n\n" + content)
+          end
+        end
 
         cocoapods_bazel_path = File.join(sandbox.root, 'cocoapods-bazel')
         FileUtils.mkdir_p cocoapods_bazel_path

--- a/lib/cocoapods/bazel/config.rb
+++ b/lib/cocoapods/bazel/config.rb
@@ -40,8 +40,7 @@ module Pod
         # This might be ok for some teams but it prevents others that are interested in using cocoapods-bazel to migrate to Bazel and eventually stop
         # depending on cocoapods. If the generated BUILD files don't contain "all" states and a 'pod install' is always required it's not trivial how to eventually treat the
         # BUILD files as source of truth.
-        :experimental_deps_debug_and_release,
-        :build_file_doc
+        :experimental_deps_debug_and_release
       ].freeze
       private_constant :PLUGIN_KEY
       DEFAULTS = {
@@ -53,9 +52,9 @@ module Pod
         overrides: {}.freeze,
         buildifier: true,
         default_xcconfigs: {}.freeze,
+        build_file_doc: '',
         features: {
-          experimental_deps_debug_and_release: false,
-          build_file_doc: ""
+          experimental_deps_debug_and_release: false
         }
       }.with_indifferent_access.freeze
 
@@ -114,7 +113,7 @@ module Pod
       end
 
       def build_file_doc
-        to_h[:features][:build_file_doc]
+        to_h[:build_file_doc]
       end
     end
   end

--- a/lib/cocoapods/bazel/config.rb
+++ b/lib/cocoapods/bazel/config.rb
@@ -40,7 +40,8 @@ module Pod
         # This might be ok for some teams but it prevents others that are interested in using cocoapods-bazel to migrate to Bazel and eventually stop
         # depending on cocoapods. If the generated BUILD files don't contain "all" states and a 'pod install' is always required it's not trivial how to eventually treat the
         # BUILD files as source of truth.
-        :experimental_deps_debug_and_release
+        :experimental_deps_debug_and_release,
+        :build_file_doc
       ].freeze
       private_constant :PLUGIN_KEY
       DEFAULTS = {
@@ -53,7 +54,8 @@ module Pod
         buildifier: true,
         default_xcconfigs: {}.freeze,
         features: {
-          experimental_deps_debug_and_release: false
+          experimental_deps_debug_and_release: false,
+          build_file_doc: ""
         }
       }.with_indifferent_access.freeze
 
@@ -109,6 +111,10 @@ module Pod
 
       def experimental_deps_debug_and_release
         to_h[:features][:experimental_deps_debug_and_release]
+      end
+
+      def build_file_doc
+        to_h[:features][:build_file_doc]
       end
     end
   end

--- a/lib/cocoapods/bazel/version.rb
+++ b/lib/cocoapods/bazel/version.rb
@@ -2,6 +2,6 @@
 
 module Pod
   module Bazel
-    VERSION = '0.1.2'
+    VERSION = '0.1.3'
   end
 end

--- a/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 
 apple_framework(

--- a/spec/integration/monorepo/after/Frameworks/EsotericGlobs/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/EsotericGlobs/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 

--- a/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/c/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/c/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/d/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/d/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/e/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/e/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")
 

--- a/spec/integration/monorepo/after/Frameworks/f/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/f/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/g/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/g/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Pods/OneTrust-CMP-XCFramework/BUILD.bazel
+++ b/spec/integration/monorepo/after/Pods/OneTrust-CMP-XCFramework/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 
 apple_framework(

--- a/spec/integration/monorepo/after/Pods/OnlyPre/BUILD.bazel
+++ b/spec/integration/monorepo/after/Pods/OnlyPre/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 
 apple_framework(

--- a/spec/integration/monorepo/after/Pods/Public/BUILD.bazel
+++ b/spec/integration/monorepo/after/Pods/Public/BUILD.bazel
@@ -1,3 +1,8 @@
+'''
+Test docstring
+that takes two lines
+'''
+
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 
 apple_framework(

--- a/spec/integration/monorepo/before/Podfile
+++ b/spec/integration/monorepo/before/Podfile
@@ -4,7 +4,10 @@ ENV['COCOAPODS_DISABLE_STATS'] = '1'
 
 source 'https://github.com/CocoaPods/Specs.git'
 
-plugin 'cocoapods-bazel'
+plugin(
+  'cocoapods-bazel',
+  build_file_doc: "Test docstring\nthat takes two lines"
+)
 
 use_frameworks!
 


### PR DESCRIPTION
Add a new field to config that takes in a string and will be inserted at top of generated build.bazel file as a docstring:
```
'''
some string1
some string2
'''
load...
```
This way we can start adding statement such as `this is auto-generated code`
Since it is a docstring, no way to intro actual code via this method