### PR TITLE
Fix not using double quote instead of single quote for build file docstring feature

### DIFF
--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -71,7 +71,7 @@ module Pod
           build_files.each_key.each do |key|
             path = File.join(workspace, key, 'BUILD.bazel')
             content = File.read(path)
-            File.write(path, "'''\n#{config.build_file_doc}\n'''\n\n" + content)
+            File.write(path, "\"\"\"\n#{config.build_file_doc}\n\"\"\"\n\n" + content)
           end
         end
 

--- a/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/CustomHeaderSearchPaths/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 

--- a/spec/integration/monorepo/after/Frameworks/EsotericGlobs/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/EsotericGlobs/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/c/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/c/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/d/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/d/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/e/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/e/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 load("@build_bazel_rules_ios//rules:test.bzl", "ios_unit_test")

--- a/spec/integration/monorepo/after/Frameworks/f/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/f/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Frameworks/g/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/g/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:app.bzl", "ios_application")
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")

--- a/spec/integration/monorepo/after/Pods/OneTrust-CMP-XCFramework/BUILD.bazel
+++ b/spec/integration/monorepo/after/Pods/OneTrust-CMP-XCFramework/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 

--- a/spec/integration/monorepo/after/Pods/OnlyPre/BUILD.bazel
+++ b/spec/integration/monorepo/after/Pods/OnlyPre/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 

--- a/spec/integration/monorepo/after/Pods/Public/BUILD.bazel
+++ b/spec/integration/monorepo/after/Pods/Public/BUILD.bazel
@@ -1,7 +1,7 @@
-'''
+"""
 Test docstring
 that takes two lines
-'''
+"""
 
 load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
 


### PR DESCRIPTION
Otherwise buildifier linter will complain this and fail
I don't think version bump is required as one will get the latest commit