### PR TITLE
Bug fix for glob expansion

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -557,7 +557,7 @@ module Pod
       # E.g., xib files glob "*.xib" should not be expanded to "*.xib/**/*", otherise nothing will be matched
       def should_skip_directory_expansion(glob)
         extension = File.extname(glob)
-        expansion_extentions = Set[".xcassets", ".xcdatamodeld", ".lproj"]
+        expansion_extentions = Set['.xcassets', '.xcdatamodeld', '.lproj']
         !expansion_extentions.include?(extension)
       end
 

--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'set'
+
 require_relative 'xcconfig_resolver'
 
 module Pod
@@ -521,11 +523,11 @@ module Pod
       def expand_glob(glob, extensions: nil, expand_directories: false)
         if (m = glob.match(/\{([^\{\}]+)\}/))
           m[1].split(',').flat_map do |alt|
-            expand_glob("#{m.pre_match}#{alt}#{m.post_match}")
+            expand_glob("#{m.pre_match}#{alt.strip}#{m.post_match}", extensions: extensions, expand_directories: expand_directories)
           end.uniq
         elsif (m = glob.match(/\[([^\[\]]+)\]/))
           m[1].each_char.flat_map do |alt|
-            expand_glob("#{m.pre_match}#{alt}#{m.post_match}")
+            expand_glob("#{m.pre_match}#{alt.strip}#{m.post_match}", extensions: extensions, expand_directories: expand_directories)
           end.uniq
         elsif extensions && File.extname(glob).empty?
           glob = glob.chomp('**/*') # If we reach here and the glob ends with **/*, we need to avoid duplicating it (we do not want to end up with **/*/**/*)
@@ -541,12 +543,22 @@ module Pod
             [glob]
           elsif glob.end_with?('/*')
             [glob.sub(%r{/\*$}, '/**/*')]
+          elsif should_skip_directory_expansion(glob)
+            [glob]
           else
             [glob.chomp('/') + '/**/*']
           end
         else
           [glob]
         end
+      end
+
+      # We should expand only folder globs, not expand file globs.
+      # E.g., xib files glob "*.xib" should not be expanded to "*.xib/**/*", otherise nothing will be matched
+      def should_skip_directory_expansion(glob)
+        extension = File.extname(glob)
+        expansion_extentions = Set[".xcassets", ".xcdatamodeld", ".lproj"]
+        !expansion_extentions.include?(extension)
       end
 
       def rules_ios_platform_name(platform)

--- a/spec/integration/monorepo/after/Frameworks/GlobExpansion/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/GlobExpansion/BUILD.bazel
@@ -1,0 +1,44 @@
+"""
+Test docstring
+that takes two lines
+"""
+
+load("@build_bazel_rules_ios//rules:framework.bzl", "apple_framework")
+
+apple_framework(
+    name = "GlobExpansion",
+    platforms = {"ios": "9.0"},
+    resource_bundles = {
+        "ShouldExpand": glob(
+            [
+                "Resources/Localization/*.lproj/**/*",
+                "Resources/Images.xcassets/**/*",
+                "Resources/*.xcdatamodeld/**/*",
+            ],
+            exclude_directories = 0,
+        ),
+        "ShouldNotExpand": glob(
+            [
+                "Resources/*.xib",
+                "Resources/*.strings",
+                "Resources/*.png",
+                "Resources/*.otf",
+                "Resources/*.storyboard",
+                "Resources/**/*",
+            ],
+            exclude_directories = 0,
+        ),
+        "Composite": glob(
+            [
+                "Resources/*.strings",
+                "Resources/*.json",
+                "Resources/*.lproj/**/*",
+                "Resources/*.storyboard",
+                "Resources/*.xcassets/**/*",
+                "Resources/*.xib",
+            ],
+            exclude_directories = 0,
+        ),
+    },
+    visibility = ["//visibility:public"],
+)

--- a/spec/integration/monorepo/before/Frameworks/GlobExpansion/GlobExpansion.podspec
+++ b/spec/integration/monorepo/before/Frameworks/GlobExpansion/GlobExpansion.podspec
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+Pod::Spec.new do |s|
+    s.name = 'GlobExpansion'
+    s.version = '1.0.0.LOCAL'
+  
+    s.authors = %w[Rules-iOS]
+    s.homepage = 'https://github.com/bazel-ios/cocoapods-bazel'
+    s.source = { git: 'https://github.com/bazel-ios/cocoapods-bazel' }
+    s.summary = 'foo'
+  
+    s.swift_versions = %w[5.2]
+    s.ios.deployment_target = '9.0'
+  
+    s.ios.resource_bundle = { 
+        'ShouldExpand' => [
+            'Resources/Localization/*.lproj', 
+            'Resources/Images.xcassets',
+            'Resources/*.xcdatamodeld',
+        ],
+        'ShouldNotExpand' => [
+            'Resources/*.xib', 
+            'Resources/*.strings',
+            'Resources/*.png',
+            'Resources/*.otf',
+            'Resources/*.storyboard',
+            'Resources/**/*',
+        ],
+        'Composite' => [
+            'Resources/*.{strings,json}', 
+            'Resources/*.{lproj,storyboard,xcassets,xib}',
+        ]
+    }
+end


### PR DESCRIPTION
Bug fix for glob expansion and also add tests. 
- file glob like `Resources/*.xib` should not be expanded to `Resources/*.xib/**/*`
- `Resources/*.{lproj,storyboard,xcassets,xib}` is not handled correctly, nothing inside the `{}` is expanded