### PR TITLE
add public visibility for app_kwargs

### DIFF
--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -652,7 +652,8 @@ module Pod
           settings_bundle: [],
           strings: [],
           version: [],
-          watch_application: []
+          watch_application: [],
+          visibility: ['//visibility:public']
         }
 
         # If the user has set a different build os set that here

--- a/spec/integration/experimental_features/after/Frameworks/EsotericGlobs/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/EsotericGlobs/BUILD.bazel
@@ -32,5 +32,6 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "EsotericGlobs_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":EsotericGlobs"],
 )

--- a/spec/integration/experimental_features/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
@@ -54,5 +54,6 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "SelectPerConfigWithSharedDeps_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":SelectPerConfigWithSharedDeps"],
 )

--- a/spec/integration/experimental_features/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
@@ -51,5 +51,6 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "SelectPerConfigWithoutSharedDeps_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":SelectPerConfigWithoutSharedDeps"],
 )

--- a/spec/integration/experimental_features/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
@@ -44,6 +44,7 @@ ios_application(
     module_name = "SwiftBridgingHeader_App",
     swift_objc_bridging_header = "App/BridgingHeader.h",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {"SWIFT_OBJC_BRIDGING_HEADER": "App/BridgingHeader.h"},
     deps = [":SwiftBridgingHeader"],
 )

--- a/spec/integration/experimental_features/after/Frameworks/a/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/a/BUILD.bazel
@@ -55,6 +55,7 @@ ios_application(
         "-I/Headers/Private",
     ],
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "ARCHS": [
             "arm64",

--- a/spec/integration/experimental_features/after/Frameworks/b/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/b/BUILD.bazel
@@ -84,6 +84,7 @@ ios_application(
         ],
     }),
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "HEADER_SEARCH_PATHS_Debug": "/Headers/Private/Debug",
         "HEADER_SEARCH_PATHS_Release": "/Headers/Private/Release",
@@ -152,6 +153,7 @@ ios_application(
         ],
     }),
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "HEADER_SEARCH_PATHS_Debug": "/Headers/Private/Debug",
         "HEADER_SEARCH_PATHS_Release": "/Headers/Private/Release",

--- a/spec/integration/experimental_features/after/Frameworks/c/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/c/BUILD.bazel
@@ -48,5 +48,6 @@ ios_application(
     minimum_os_version = "11.0",
     module_name = "C_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":C"],
 )

--- a/spec/integration/experimental_features/after/Frameworks/d/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/d/BUILD.bazel
@@ -62,6 +62,7 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "D_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "TARGETED_DEVICE_FAMILY": "2",
         "SWIFT_PLATFORM_TARGET_PREFIX": "ios",

--- a/spec/integration/experimental_features/after/Frameworks/f/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/f/BUILD.bazel
@@ -47,5 +47,6 @@ ios_application(
     minimum_os_version = "11.0",
     module_name = "F_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":F"],
 )

--- a/spec/integration/experimental_features/after/Frameworks/g/BUILD.bazel
+++ b/spec/integration/experimental_features/after/Frameworks/g/BUILD.bazel
@@ -47,6 +47,7 @@ ios_application(
     minimum_os_version = "11.0",
     module_name = "G_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [
         ":G",
         "//Frameworks/a:A",

--- a/spec/integration/monorepo/after/Frameworks/EsotericGlobs/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/EsotericGlobs/BUILD.bazel
@@ -37,5 +37,6 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "EsotericGlobs_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":EsotericGlobs"],
 )

--- a/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithSharedDeps/BUILD.bazel
@@ -55,5 +55,6 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "SelectPerConfigWithSharedDeps_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":SelectPerConfigWithSharedDeps"],
 )

--- a/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SelectPerConfigWithoutSharedDeps/BUILD.bazel
@@ -52,5 +52,6 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "SelectPerConfigWithoutSharedDeps_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":SelectPerConfigWithoutSharedDeps"],
 )

--- a/spec/integration/monorepo/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/SwiftBridgingHeader/BUILD.bazel
@@ -49,6 +49,7 @@ ios_application(
     module_name = "SwiftBridgingHeader_App",
     swift_objc_bridging_header = "App/BridgingHeader.h",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {"SWIFT_OBJC_BRIDGING_HEADER": "App/BridgingHeader.h"},
     deps = [":SwiftBridgingHeader"],
 )

--- a/spec/integration/monorepo/after/Frameworks/UsingPodEnvVars/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/UsingPodEnvVars/BUILD.bazel
@@ -68,6 +68,7 @@ ios_application(
         "-I/Headers/Private",
     ],
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "ARCHS": [
             "arm64",

--- a/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/a/BUILD.bazel
@@ -60,6 +60,7 @@ ios_application(
         "-I/Headers/Private",
     ],
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "ARCHS": [
             "arm64",

--- a/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/b/BUILD.bazel
@@ -89,6 +89,7 @@ ios_application(
         ],
     }),
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "HEADER_SEARCH_PATHS_Debug": "/Headers/Private/Debug",
         "HEADER_SEARCH_PATHS_Release": "/Headers/Private/Release",
@@ -157,6 +158,7 @@ ios_application(
         ],
     }),
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "HEADER_SEARCH_PATHS_Debug": "/Headers/Private/Debug",
         "HEADER_SEARCH_PATHS_Release": "/Headers/Private/Release",

--- a/spec/integration/monorepo/after/Frameworks/c/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/c/BUILD.bazel
@@ -53,5 +53,6 @@ ios_application(
     minimum_os_version = "11.0",
     module_name = "C_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":C"],
 )

--- a/spec/integration/monorepo/after/Frameworks/d/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/d/BUILD.bazel
@@ -67,6 +67,7 @@ ios_application(
     minimum_os_version = "9.0",
     module_name = "D_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     xcconfig = {
         "TARGETED_DEVICE_FAMILY": "2",
         "SWIFT_PLATFORM_TARGET_PREFIX": "ios",

--- a/spec/integration/monorepo/after/Frameworks/f/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/f/BUILD.bazel
@@ -52,5 +52,6 @@ ios_application(
     minimum_os_version = "11.0",
     module_name = "F_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [":F"],
 )

--- a/spec/integration/monorepo/after/Frameworks/g/BUILD.bazel
+++ b/spec/integration/monorepo/after/Frameworks/g/BUILD.bazel
@@ -52,6 +52,7 @@ ios_application(
     minimum_os_version = "11.0",
     module_name = "G_App",
     swift_version = "5.2",
+    visibility = ["//visibility:public"],
     deps = [
         ":G",
         "//Frameworks/a:A",


### PR DESCRIPTION
We are running into a visibility issue for when using an app_spec as test host from other pod.
For example we add an app_spec at VoyagerUnitTestLib.podspec like
```
  s.app_spec 'TestHost' do |app_spec|
    app_spec.source_files = 'TestHost/**/*.swift'
    app_spec.pod_target_xcconfig = { 'INFOPLIST_FILE' => 'TestHost/info.plist' }
  end
```
then try to use this app TestHost from MemberAnalytics.podspec like
```
s.test_spec 'Tests' do |test_spec|
    test_spec.requires_app_host = true
    test_spec.app_host_name = 'VoyagerUnitTestLib/TestHost'
    test_spec.dependency 'VoyagerUnitTestLib/TestHost'
  end
```
pod bazelize will fail with error
```
ERROR: /Users/guoli/Documents/github/voyager-ios-release/voyager-ios/Source/Pillars/Premium/MemberAnalytics/MemberAnalytics/BUILD.bazel:27:14: in dep_middleman rule //Source/Pillars/Premium/MemberAnalytics/MemberAnalytics:MemberAnalytics-Unit-Tests.dep_middleman: target '//Testing/VoyagerUnitTestLib:VoyagerUnitTestLib-TestHost' is not visible from target '//Source/Pillars/Premium/MemberAnalytics/MemberAnalytics:MemberAnalytics-Unit-Tests.dep_middleman'. Check the visibility declaration of the former target if you think the dependency is legitimate
ERROR: /Users/guoli/Documents/github/voyager-ios-release/voyager-ios/Source/Pillars/Premium/MemberAnalytics/MemberAnalytics/BUILD.bazel:27:14: Analysis of target '//Source/Pillars/Premium/MemberAnalytics/MemberAnalytics:MemberAnalytics-Unit-Tests.dep_middleman' failed
```
the change add public visibility of the application 