### PR TITLE
Bump `starlark_compiler` to allow Ruby 3

### DIFF
--- a/cocoapods-bazel.gemspec
+++ b/cocoapods-bazel.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '>= 2.1'
 
-  spec.add_runtime_dependency 'starlark_compiler', '~> 0.3'
+  spec.add_runtime_dependency 'starlark_compiler', '~> 0.5'
 
   spec.required_ruby_version = '>= 2.6'
 end


### PR DESCRIPTION
# Summary
Allow consumers to use https://github.com/segiddins/starlark_compiler/pull/7 in `starlark_compiler`. Let me know if anyone feels this should be `'>= 0.3'` or similar.