### PR TITLE
Add enable_add_testonly flag to help opt out the new feature added in 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.1.7
+* Adding `testonly` to targets that link with XCTest becomes an opt-in with config `enable_add_testonly`
+
 0.1.6
 * New xcframework_excluded_platforms option
 * Add .ruby-version file, update github action code

--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -45,7 +45,8 @@ module Pod
               fa.spec,
               default_xcconfigs,
               config.experimental_deps_debug_and_release,
-              config.xcframework_excluded_platforms
+              config.xcframework_excluded_platforms,
+              config.enable_add_testonly
             )
           end
 
@@ -55,7 +56,8 @@ module Pod
             nil,
             default_xcconfigs,
             config.experimental_deps_debug_and_release,
-            config.xcframework_excluded_platforms
+            config.xcframework_excluded_platforms,
+            config.enable_add_testonly
           )
 
           bazel_targets = [default_target] + targets_without_library_specification

--- a/lib/cocoapods/bazel/config.rb
+++ b/lib/cocoapods/bazel/config.rb
@@ -56,7 +56,8 @@ module Pod
         features: {
           experimental_deps_debug_and_release: false
         },
-        xcframework_excluded_platforms: [].freeze
+        xcframework_excluded_platforms: [].freeze,
+        enable_add_testonly: false
       }.with_indifferent_access.freeze
 
       private_constant :DEFAULTS
@@ -119,6 +120,10 @@ module Pod
 
       def xcframework_excluded_platforms
         to_h[:xcframework_excluded_platforms]
+      end
+
+      def enable_add_testonly
+        to_h[:enable_add_testonly]
       end
     end
   end

--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -379,10 +379,10 @@ module Pod
         kwargs[:runtime_deps] = []
         kwargs[:sdk_dylibs] = file_accessors.flat_map { |fa| fa.spec_consumer.libraries }.sort.uniq
         kwargs[:sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.frameworks }.sort.uniq
-        kwargs[:testonly] = true if kwargs[:sdk_frameworks].include? 'XCTest' && @enable_add_testonly
+        kwargs[:testonly] = true (if kwargs[:sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
         kwargs[:sdk_includes] = []
         kwargs[:weak_sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.weak_frameworks }.sort.uniq
-        kwargs[:testonly] = true if kwargs[:weak_sdk_frameworks].include? 'XCTest' && @enable_add_testonly
+        kwargs[:testonly] = true (if kwargs[:weak_sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
 
         kwargs[:vendored_static_frameworks] = glob(attr: :vendored_static_frameworks, return_files: true)
         kwargs[:vendored_dynamic_frameworks] = glob(attr: :vendored_dynamic_frameworks, return_files: true)

--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -35,7 +35,8 @@ module Pod
       private :installer, :pod_target, :file_accessors, :non_library_spec, :label, :package, :default_xcconfigs, :resolved_xconfig_by_config, :relative_sandbox_root
       # rubocop:enable Style/AccessModifierDeclarations
 
-      def initialize(installer, pod_target, non_library_spec = nil, default_xcconfigs = {}, experimental_deps_debug_and_release = false, xcframework_excluded_platforms = [], enable_add_testonly = false)
+      def initialize(installer, pod_target, non_library_spec = nil, default_xcconfigs = {}, experimental_deps_debug_and_release = false,
+                     xcframework_excluded_platforms = [], enable_add_testonly = false)
         @installer = installer
         @pod_target = pod_target
         @file_accessors = non_library_spec ? pod_target.file_accessors.select { |fa| fa.spec == non_library_spec } : pod_target.file_accessors.select { |fa| fa.spec.library_specification? }
@@ -379,10 +380,10 @@ module Pod
         kwargs[:runtime_deps] = []
         kwargs[:sdk_dylibs] = file_accessors.flat_map { |fa| fa.spec_consumer.libraries }.sort.uniq
         kwargs[:sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.frameworks }.sort.uniq
-        kwargs[:testonly] = true if (kwargs[:sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
+        kwargs[:testonly] = true if (kwargs[:sdk_frameworks].include? 'XCTest') && @enable_add_testonly
         kwargs[:sdk_includes] = []
         kwargs[:weak_sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.weak_frameworks }.sort.uniq
-        kwargs[:testonly] = true if (kwargs[:weak_sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
+        kwargs[:testonly] = true if (kwargs[:weak_sdk_frameworks].include? 'XCTest') && @enable_add_testonly
 
         kwargs[:vendored_static_frameworks] = glob(attr: :vendored_static_frameworks, return_files: true)
         kwargs[:vendored_dynamic_frameworks] = glob(attr: :vendored_dynamic_frameworks, return_files: true)

--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -379,10 +379,10 @@ module Pod
         kwargs[:runtime_deps] = []
         kwargs[:sdk_dylibs] = file_accessors.flat_map { |fa| fa.spec_consumer.libraries }.sort.uniq
         kwargs[:sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.frameworks }.sort.uniq
-        kwargs[:testonly] = true (if kwargs[:sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
+        kwargs[:testonly] = true if (kwargs[:sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
         kwargs[:sdk_includes] = []
         kwargs[:weak_sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.weak_frameworks }.sort.uniq
-        kwargs[:testonly] = true (if kwargs[:weak_sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
+        kwargs[:testonly] = true if (kwargs[:weak_sdk_frameworks].include? 'XCTest' && @enable_add_testonly)
 
         kwargs[:vendored_static_frameworks] = glob(attr: :vendored_static_frameworks, return_files: true)
         kwargs[:vendored_dynamic_frameworks] = glob(attr: :vendored_dynamic_frameworks, return_files: true)

--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -35,7 +35,7 @@ module Pod
       private :installer, :pod_target, :file_accessors, :non_library_spec, :label, :package, :default_xcconfigs, :resolved_xconfig_by_config, :relative_sandbox_root
       # rubocop:enable Style/AccessModifierDeclarations
 
-      def initialize(installer, pod_target, non_library_spec = nil, default_xcconfigs = {}, experimental_deps_debug_and_release = false, xcframework_excluded_platforms = [])
+      def initialize(installer, pod_target, non_library_spec = nil, default_xcconfigs = {}, experimental_deps_debug_and_release = false, xcframework_excluded_platforms = [], enable_add_testonly = false)
         @installer = installer
         @pod_target = pod_target
         @file_accessors = non_library_spec ? pod_target.file_accessors.select { |fa| fa.spec == non_library_spec } : pod_target.file_accessors.select { |fa| fa.spec.library_specification? }
@@ -47,6 +47,7 @@ module Pod
         @resolved_xconfig_by_config = {}
         @experimental_deps_debug_and_release = experimental_deps_debug_and_release
         @xcframework_excluded_platforms = xcframework_excluded_platforms
+        @enable_add_testonly = enable_add_testonly
         @relative_sandbox_root = installer.sandbox.root.relative_path_from(installer.config.installation_root).to_s
       end
 
@@ -378,10 +379,10 @@ module Pod
         kwargs[:runtime_deps] = []
         kwargs[:sdk_dylibs] = file_accessors.flat_map { |fa| fa.spec_consumer.libraries }.sort.uniq
         kwargs[:sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.frameworks }.sort.uniq
-        kwargs[:testonly] = true if kwargs[:sdk_frameworks].include? 'XCTest'
+        kwargs[:testonly] = true if kwargs[:sdk_frameworks].include? 'XCTest' && @enable_add_testonly
         kwargs[:sdk_includes] = []
         kwargs[:weak_sdk_frameworks] = file_accessors.flat_map { |fa| fa.spec_consumer.weak_frameworks }.sort.uniq
-        kwargs[:testonly] = true if kwargs[:weak_sdk_frameworks].include? 'XCTest'
+        kwargs[:testonly] = true if kwargs[:weak_sdk_frameworks].include? 'XCTest' && @enable_add_testonly
 
         kwargs[:vendored_static_frameworks] = glob(attr: :vendored_static_frameworks, return_files: true)
         kwargs[:vendored_dynamic_frameworks] = glob(attr: :vendored_dynamic_frameworks, return_files: true)

--- a/lib/cocoapods/bazel/version.rb
+++ b/lib/cocoapods/bazel/version.rb
@@ -2,6 +2,6 @@
 
 module Pod
   module Bazel
-    VERSION = '0.1.6'
+    VERSION = '0.1.7'
   end
 end


### PR DESCRIPTION
testonly attribute is disruptive because all downstreams deps now must have testonly too.
So it's better to have it opt out by default, so downstreams deps can fix all before turn it back on